### PR TITLE
Re-usable mkdocs deployment action

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,0 +1,76 @@
+name: Deploy MkDocs
+
+on:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      repo:
+        type: string
+        required: true
+      branch_name:
+        type: string
+        required: true
+        default: "main"
+    secrets:
+      token:
+        required: true
+      user:
+        required: true
+      email:
+        required: true
+
+env:
+  GH_TOKEN: ${{ secrets.token || secrets.YNPUT_BOT_TOKEN }}
+  GH_USER: ${{ secrets.user || secrets.CI_USER }}
+  GH_EMAIL: ${{ secrets.email || secrets.CI_EMAIL }}
+
+jobs:
+  verify-repo-secrets:
+    uses: ynput/ops-repo-automation/.github/workflows/verify_secrets.yml@main
+    with:
+      repo: ${{ github.repository }}
+    secrets:
+      gh_token: ${{ secrets.token }}
+      gh_user: ${{ secrets.user }}
+      gh_email: ${{ secrets.email }}
+
+  deploy:
+    if: ${{ always() && hashFiles('./mkdocs.yml') != '' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # FIXME: The branch name in checkout@v4 defaults to 'master' but our default
+      # is 'develop' or 'main'. We should run this on 'main', as a last step of
+      # the release process.
+      - name: Checkout ${{ inputs.branch_name}}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_name}}
+          fetch-depth: 0
+          submodules: true
+
+      - name: 🔑 Set Authentication
+        run: |
+          git config --global user.name "${{ secrets.user || secrets.CI_USER }}"
+          git config --global user.email "${{ secrets.email || secrets.CI_EMAIL }}"
+
+      - name: Get current tag
+        id: git_tag
+        uses: devops-actions/action-get-tag@v1.0.3
+        with:
+          default: 1.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        # FIXME: This could be cached.
+        run: |
+          python3 -m pip install -r ./mkdocs_requirements.txt
+
+      - name: Mike deploy ${{ steps.git_tag.outputs.tag }}
+        run: mike deploy --update-aliases ${{ steps.git_tag.outputs.tag }} latest

--- a/.github/workflows/release_trigger.yml
+++ b/.github/workflows/release_trigger.yml
@@ -129,7 +129,7 @@ jobs:
 
     uses: ynput/ops-repo-automation/.github/workflows/build_from_branch.yml@main
     with:
-      repo:   ${{ github.repository }}
+      repo: ${{ github.repository }}
       branch_name: ${{ vars.MAIN_BRANCH }}
       project_name: ${{ vars.PROJECT_NAME }}
       artifact_name: "${{ vars.PROJECT_NAME }}-package"
@@ -137,7 +137,7 @@ jobs:
     secrets:
       gh_token: ${{ secrets.token }}
       gh_user: ${{ secrets.user }}
-      gh_email: ${{ secrets.email }} 
+      gh_email: ${{ secrets.email }}
 
   update-develop:
     needs:
@@ -199,3 +199,17 @@ jobs:
       gh_token: ${{ secrets.token }}
 
     # TODO verify tag position
+
+  deploy-documentation:
+    needs:
+      - increment-version
+      - merge-to-main
+    # FIXME: switch to main, NOT develop BEFORE releasing
+    uses: ynput/ops-repo-automation/.github/workflows/deploy_mkdocs.yml@develop
+    with:
+      repo: ${{ github.repository }}
+      branch_name: main
+    secrets:
+      gh_token: ${{ secrets.token }}
+      gh_user: ${{ secrets.user }}
+      gh_email: ${{ secrets.email }}

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,0 +1,9 @@
+mkdocs-material >= 9.6.7
+mkdocs-autoapi >= 0.4.0
+mkdocstrings-python >= 1.16.2
+mkdocs-minify-plugin >= 0.8.0
+markdown-checklist >= 0.4.4
+mdx-gh-links >= 0.4
+pymdown-extensions >= 10.14.3
+mike >= 2.1.3
+mkdocstrings-shell >= 1.0.2


### PR DESCRIPTION
# Create re-usable mkdocs deployment action

## Summary

This is adding a re-usable mkdocs action and adding it to the release trigger.

## Root Cause Analysis

Most addon repos have been setup to generate their own documentation and need to update the documentation for each new release.

## Changelog

* `mkdocs_requirements.txt` to install all required python modules.
* `.github/workflows/deploy_mkdocs.yml` is the re-usable action.
* `.github/workflows/release_trigger.yml` now calls deploy_mkdocs.

## Testing Strategy

At first, we need to create this PR and then test it from another repo, like ayon-core.
