### PR TITLE
Add re-usable mkdocs workflow

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,0 +1,61 @@
+name: Deploy MkDocs
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      repo:
+        type: string
+        required: true
+    secrets:
+      YNPUT_BOT_TOKEN:
+        required: true
+      CI_USER:
+        required: true
+      CI_EMAIL:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo }}
+          token: ${{ secrets.YNPUT_BOT_TOKEN }}
+          fetch-depth: 0
+          submodules: true
+
+      - name: 🔑 Set Authentication
+        run: |
+          git config --global user.name "${{ secrets.CI_USER }}"
+          git config --global user.email "${{ secrets.CI_EMAIL }}"
+
+      - name: Get current tag
+        id: git_tag
+        uses: devops-actions/action-get-tag@v1.0.3
+        with:
+          default: test-build
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -r mkdocs_requirements.txt
+
+      - name: Mike deploy ${{ steps.git_tag.outputs.tag }}
+        run: |
+          mike deploy --update-aliases ${{ steps.git_tag.outputs.tag }} latest --branch gh-pages --push
+          mike set-default latest --branch gh-pages --push
+      - name: Remove dummy version on triggering from a tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mike delete test-build --branch gh-pages --push
+


### PR DESCRIPTION
## Changelog Description

Add re-usable mkdocs workflow.
Resolve #34

## Testing Strategy
- You can trigger it manually via gh cli and provide repository 
```
gh workflow run deploy_mkdocs.yml --ref feature/34-add-mk-docs-reusable-workflow -f repo=ynput/ayon-core
```
- you can trigger it from core addon PR https://github.com/ynput/ayon-core/pull/1441